### PR TITLE
Feature: on_social_set callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,7 +480,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "contract"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "near-contract-standards",
  "near-sdk",

--- a/contract/src/api.rs
+++ b/contract/src/api.rs
@@ -189,8 +189,7 @@ impl Contract {
             env::panic_str("The attached deposit could not be added to any account");
         }
 
-        if options.callback_receiver_id.is_some() {
-            let callback_receiver_id = options.callback_receiver_id.unwrap();
+        if let Some(callback_receiver_id) = options.callback_receiver_id {
 
             callback_contract::on_social_set(
                 near_sdk::env::block_height(),

--- a/contract/src/api.rs
+++ b/contract/src/api.rs
@@ -1,14 +1,14 @@
 use crate::*;
-use near_sdk::ext_contract;
 use near_sdk::json_types::U64;
 use near_sdk::serde_json::map::Entry;
 use near_sdk::serde_json::{Map, Value};
+use near_sdk::{ext_contract, BlockHeight};
 use near_sdk::{require, Gas};
 use std::collections::HashSet;
 
 #[ext_contract(callback_contract)]
 trait CallbackContract {
-    fn on_social_set(&self) -> Promise;
+    fn on_social_set(&self, block_height: BlockHeight) -> Promise;
 }
 
 pub const MAX_KEY_LENGTH: usize = 256;
@@ -192,9 +192,12 @@ impl Contract {
         if options.callback_receiver_id.is_some() {
             let callback_receiver_id = options.callback_receiver_id.unwrap();
 
-            let promise = callback_contract::ext(callback_receiver_id.clone())
-                .with_static_gas(Gas(5 * TGAS))
-                .on_social_set(U64(near_sdk::env::block_height()));
+            callback_contract::on_social_set(
+                near_sdk::env::block_height(),
+                callback_receiver_id.clone(),
+                0,
+                Gas(5 * TGAS),
+            );
         }
 
         SetReturnType {

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1,21 +1,21 @@
 mod account;
 mod api;
+mod legacy;
 mod node;
 mod permission;
+mod shared_storage;
 mod storage_tracker;
 mod upgrade;
 mod utils;
-mod legacy;
-mod shared_storage;
 
 pub use crate::account::*;
 pub use crate::api::*;
+use crate::legacy::*;
 pub use crate::node::*;
 pub use crate::permission::*;
 pub use crate::shared_storage::*;
 use crate::storage_tracker::*;
 use crate::utils::*;
-use crate::legacy::*;
 
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::{LookupMap, UnorderedMap};


### PR DESCRIPTION
At [Devhub](https://github.com/NEAR-DevHub) we could benefit from having an option to ask set method in SocialDB to make a cross-contract call to another contract to inform about the change. The use-case - we want to be able to make a post through NEAR Social (`<account>/post/main`) and trigger DevHub's contract, so it reshares the created post (we need block height and the updated keys to be provided from SocialDB contract). As mentioned by [@frol](https://github.com/frol) [here](https://t.me/NearSocialDev/5882) 

I extended the set function with a callback and added callback_receiver_id to setoptions.

@evgenykuzyakov I wanted to solicit your feedbank. I implemented it so that the the receiver method is fixed as you mentioned. If you have any additional considerations or suggestions, please let me know. I'll incorporate them into the implementation, write a test case and remove the draft status from the PR.